### PR TITLE
fix(opencode): extract model from message.data modelID instead of part data

### DIFF
--- a/src/llm_usage/collectors/opencode.py
+++ b/src/llm_usage/collectors/opencode.py
@@ -67,24 +67,22 @@ def _extract_tokens_from_part_data(data: str) -> Optional[tuple[int, int, int]]:
     return input_tokens, cache_tokens, output_tokens
 
 
-def _extract_model_from_part_data(data: str) -> str:
-    """Extract model name from part data JSON.
+def _extract_model_from_message_data(data: str) -> str:
+    """Extract model name from message data JSON.
 
-    Looks for model info in step-start events.
+    OpenCode stores the model identifier in the message table's data field
+    as ``modelID``, not in the part table's step-finish/step-start events.
     """
     try:
         obj: dict[str, Any] = json.loads(data)
     except json.JSONDecodeError:
         return "unknown"
 
-    # Check for model in various places
-    if obj.get("type") == "step-start":
-        # Some step-start events may have model info
-        model = obj.get("model")
-        if isinstance(model, str) and model.strip():
-            return model.strip()
+    model = obj.get("modelID")
+    if isinstance(model, str) and model.strip():
+        return model.strip()
 
-    # Also check for model in nested structures
+    # Fallback: check common alternative keys
     for key in ("model", "model_name", "modelName"):
         value = obj.get(key)
         if isinstance(value, str) and value.strip():
@@ -142,10 +140,10 @@ class OpenCodeCollector(BaseCollector):
             cursor = conn.cursor()
 
             # Query parts with Token Data
-            # Join with Message and Session to get timestamps
+            # Join with Message and Session to get timestamps and model info
             # Use LIKE patterns that match both compact and pretty-printed JSON
             query = """
-                SELECT p.data, p.time_created, s.directory
+                SELECT p.data, p.time_created, s.directory, m.data as message_data
                 FROM part p
                 JOIN message m ON p.message_id = m.id
                 JOIN session s ON m.session_id = s.id
@@ -157,7 +155,7 @@ class OpenCodeCollector(BaseCollector):
             rows = cursor.fetchall()
             conn.close()
 
-            for data, time_created, directory in rows:
+            for data, time_created, directory, message_data in rows:
                 tokens = _extract_tokens_from_part_data(str(data))
                 if tokens is None:
                     continue
@@ -172,7 +170,7 @@ class OpenCodeCollector(BaseCollector):
                 if not (start <= event_time <= end):
                     continue
 
-                model = _extract_model_from_part_data(str(data))
+                model = _extract_model_from_message_data(str(message_data))
 
                 events.append(
                     UsageEvent(

--- a/tests/test_opencode_collector.py
+++ b/tests/test_opencode_collector.py
@@ -12,7 +12,7 @@ import pytest
 from llm_usage.collectors import OpenCodeCollector, build_opencode_collector
 from llm_usage.collectors.opencode import (
     _extract_tokens_from_part_data,
-    _extract_model_from_part_data,
+    _extract_model_from_message_data,
 )
 
 
@@ -46,19 +46,34 @@ class TestOpenCodeCollectorHelpers:
         result = _extract_tokens_from_part_data(data)
         assert result is None
 
-    def test_extract_model_from_data(self) -> None:
-        """Test extracting model name."""
+    def test_extract_model_from_message_data_modelid(self) -> None:
+        """Test extracting model name from message data via modelID."""
         data = json.dumps({
-            "type": "step-start",
+            "role": "assistant",
+            "modelID": "glm-5.1",
+            "providerID": "opencode",
+        })
+        result = _extract_model_from_message_data(data)
+        assert result == "glm-5.1"
+
+    def test_extract_model_from_message_data_fallback_model(self) -> None:
+        """Test fallback to 'model' key when modelID is absent."""
+        data = json.dumps({
+            "role": "assistant",
             "model": "claude-3-5-sonnet",
         })
-        result = _extract_model_from_part_data(data)
+        result = _extract_model_from_message_data(data)
         assert result == "claude-3-5-sonnet"
 
     def test_extract_model_returns_unknown(self) -> None:
         """Test that unknown model returns 'unknown'."""
-        data = json.dumps({"type": "other"})
-        result = _extract_model_from_part_data(data)
+        data = json.dumps({"role": "user"})
+        result = _extract_model_from_message_data(data)
+        assert result == "unknown"
+
+    def test_extract_model_invalid_json(self) -> None:
+        """Test that invalid JSON returns 'unknown'."""
+        result = _extract_model_from_message_data("not json")
         assert result == "unknown"
 
 
@@ -97,7 +112,9 @@ class TestOpenCodeCollector:
             CREATE TABLE message (
                 id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
-                time_created INTEGER NOT NULL
+                time_created INTEGER NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
             )
         """)
         cursor.execute("""
@@ -106,7 +123,9 @@ class TestOpenCodeCollector:
                 message_id TEXT NOT NULL,
                 session_id TEXT NOT NULL,
                 time_created INTEGER NOT NULL,
-                data TEXT NOT NULL
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL,
+                FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE
             )
         """)
 
@@ -117,15 +136,26 @@ class TestOpenCodeCollector:
             ("sess-1", "proj-1", "/tmp/test", "Test Session"),
         )
         cursor.execute(
-            "INSERT INTO message (id, session_id, time_created) VALUES (?, ?, ?)",
-            ("msg-1", "sess-1", now_ms),
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            (
+                "msg-1",
+                "sess-1",
+                now_ms,
+                now_ms,
+                json.dumps({
+                    "role": "assistant",
+                    "modelID": "glm-5.1",
+                    "providerID": "opencode",
+                }),
+            ),
         )
         cursor.execute(
-            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
             (
                 "part-1",
                 "msg-1",
                 "sess-1",
+                now_ms,
                 now_ms,
                 json.dumps({
                     "type": "step-finish",
@@ -149,6 +179,7 @@ class TestOpenCodeCollector:
         assert len(output.events) == 1
         event = output.events[0]
         assert event.tool == "opencode"
+        assert event.model == "glm-5.1"
         assert event.input_tokens == 100
         assert event.output_tokens == 50
         assert event.cache_tokens == 210


### PR DESCRIPTION
## Problem

OpenCode collector reports all events with model `"unknown"` because the model name is never found.

## Root Cause

The OpenCode SQLite database stores the model identifier in the **`message` table**'s `data` field as `modelID`:

```json
{"role": "assistant", "modelID": "glm-5.1", "providerID": "opencode", "tokens": {...}}
```

However, the previous code tried to extract the model from the **`part` table**'s `step-finish` / `step-start` events, which do not contain any model field:

```json
{"type": "step-finish", "reason": "tool-calls", "tokens": {...}}
{"type": "step-start"}
```

So `_extract_model_from_part_data()` always returned `"unknown"`.

## Fix

- Rename `_extract_model_from_part_data` to `_extract_model_from_message_data`
- SQL query now SELECTs `m.data as message_data` alongside existing fields
- Extract model via `obj.get("modelID")` from message data JSON
- Fallback to `"model"`, `"model_name"`, `"modelName"` keys for compatibility

## Verification

- 418 tests all pass
- Verified against real opencode.db: **3,144 events, 0 unknown models**

Before fix:

```
Model    Events
unknown  3,144
```

After fix:

```
Model            Events
gemini-3.1-pro   1,198
mimo-v2-pro      1,130
glm-5.1            798
MiniMax-M2.7        18
unknown              0
```

## Files Changed

- `src/llm_usage/collectors/opencode.py` - fix model extraction logic + SQL query
- `tests/test_opencode_collector.py` - updated tests with realistic schema and modelID
